### PR TITLE
Fix null reference exception in DrawChannels

### DIFF
--- a/ChatAlerts/Gui/Interface.cs
+++ b/ChatAlerts/Gui/Interface.cs
@@ -257,7 +257,7 @@ public class Interface : IDisposable
                 if (chatType == XivChatType.CrossParty || chatType == XivChatType.Debug || chatType == XivChatType.Urgent)
                     continue;
 
-                var name = chatType == XivChatType.None ? "All" : chatType.GetDetails().FancyName;
+                var name = chatType == XivChatType.None ? "All" : chatType.GetAttribute<XivChatTypeInfoAttribute>()?.FancyName ?? Enum.GetName(chatType);
                 var e    = alert.Channels.Contains(chatType);
 
                 if (ImGui.Checkbox($"{name}##alertChannelOption{(ushort)chatType}", ref e))


### PR DESCRIPTION
The channel dropdown list is not rendering correctly because it throws a null reference exception.
Reason is that the `XivChatType` entry after Shout, [TellOutgoing](https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/Text/XivChatType.cs#L45), does not have a `XivChatTypeInfoAttribute` and [XivChatTypeExtensions.GetDetails()](https://github.com/goatcorp/Dalamud/blob/master/Dalamud/Game/Text/XivChatTypeExtensions.cs#L15) doesn't return a nullable, thus reading `FancyName` of null.

With the fix applied, it renders "correctly", falling back to the enum name:

![Screenshot](https://github.com/user-attachments/assets/7d38fbd9-d650-4102-bddd-83f90e12b756)

Fixes #9 