### PR TITLE
feat: Added ZoneType filter option

### DIFF
--- a/ChatAlerts/Alert.cs
+++ b/ChatAlerts/Alert.cs
@@ -8,6 +8,7 @@ namespace ChatAlerts
     public class Alert : IDisposable
     {
         public readonly List<XivChatType> Channels  = [];
+        public readonly List<ZoneType>    Zones     = [];
         public          string            Name      = "New Alert";
         public          string            Content   = string.Empty;
         public          string            SoundPath = string.Empty;

--- a/ChatAlerts/ChatWatcher.cs
+++ b/ChatAlerts/ChatWatcher.cs
@@ -12,15 +12,18 @@ public class ChatWatcher : IDisposable
 {
     private readonly SortedSet<XivChatType> _watchedChannels = new();
     private          bool                   _watchAllChannels;
+    private          ZoneType               _currentZoneType;
 
     private static List<Alert> Alerts
         => ChatAlerts.Config.Alerts;
 
     public ChatWatcher()
     {
+        _currentZoneType = ZoneTypeExtensions.GetCurrentZoneType();
         UpdateAllAlerts();
-        Dalamud.Chat.CheckMessageHandled += OnCheckMessageHandled;
-        Dalamud.Chat.ChatMessage         += OnChatMessage;
+        Dalamud.Chat.CheckMessageHandled          += OnCheckMessageHandled;
+        Dalamud.Chat.ChatMessage                  += OnChatMessage;
+        Dalamud.ClientState.TerritoryChanged      += OnTerritoryChanged;
     }
 
     internal void UpdateAllAlerts()
@@ -44,9 +47,13 @@ public class ChatWatcher : IDisposable
 
     public void Dispose()
     {
-        Dalamud.Chat.CheckMessageHandled -= OnCheckMessageHandled;
-        Dalamud.Chat.ChatMessage         -= OnChatMessage;
+        Dalamud.Chat.CheckMessageHandled     -= OnCheckMessageHandled;
+        Dalamud.Chat.ChatMessage             -= OnChatMessage;
+        Dalamud.ClientState.TerritoryChanged -= OnTerritoryChanged;
     }
+
+    private void OnTerritoryChanged(uint territoryId)
+        => _currentZoneType = ZoneTypeExtensions.GetCurrentZoneType(territoryId);
 
     private static void CopySublist(IReadOnlyList<Payload> payloads, List<Payload> newPayloads, int from, int to)
     {
@@ -122,7 +129,8 @@ public class ChatWatcher : IDisposable
         foreach (var alert in Alerts.Where(a => a.Enabled
                   && a.CanMatch()
                   && a.IncludeHidden == preFilter
-                  && (a.Channels.Contains(XivChatType.None) || a.Channels.Contains(message.LogKind))))
+                  && (a.Channels.Contains(XivChatType.None) || a.Channels.Contains(message.LogKind))
+                  && (a.Zones.Count == 0 || a.Zones.Contains(ZoneType.All) || a.Zones.Contains(_currentZoneType))))
         {
             var payloads   = alert.SenderAlert ? message.Sender.Payloads : message.Message.Payloads;
             var alertMatch = HandleAlert(alert, payloads, out payloads);

--- a/ChatAlerts/Dalamud.cs
+++ b/ChatAlerts/Dalamud.cs
@@ -18,6 +18,7 @@ public class Dalamud
         [PluginService] public static ISigScanner            SigScanner      { get; private set; } = null!;
         [PluginService] public static IDataManager           GameData        { get; private set; } = null!;
         [PluginService] public static IChatGui               Chat            { get; private set; } = null!;
+        [PluginService] public static IClientState           ClientState     { get; private set; } = null!;
         [PluginService] public static IPluginLog             Log             { get; private set; } = null!;
         [PluginService] public static IGameInteropProvider   Interop         { get; private set; } = null!;
     // @formatter:on

--- a/ChatAlerts/Gui/Interface.cs
+++ b/ChatAlerts/Gui/Interface.cs
@@ -168,6 +168,8 @@ public class Interface : IDisposable
 
         DrawChannels(alert, idx);
 
+        DrawZones(alert, idx);
+
         DrawHighlights(alert, idx);
 
         DrawAudio(alert, idx);
@@ -279,6 +281,46 @@ public class Interface : IDisposable
                 if (chatType == XivChatType.None && e)
                     break;
             }
+        }
+    }
+
+    private void DrawZones(Alert alert, int idx)
+    {
+        AlignLabel("Zones:");
+        var zoneListStr = alert.Zones.Count == 0 || alert.Zones.Contains(ZoneType.All)
+            ? "All"
+            : string.Join(", ", alert.Zones.Where(z => z != ZoneType.All).Select(z => z.ToDisplayName()));
+        if (!ImGui.BeginCombo($"##alertZones{idx}", zoneListStr, ImGuiComboFlags.HeightLarge))
+            return;
+
+        using var raii = ImGuiRaii.DeferredEnd(ImGui.EndCombo);
+
+        foreach (var zoneType in (ZoneType[])Enum.GetValues(typeof(ZoneType)))
+        {
+            var isAll = zoneType == ZoneType.All;
+            var e     = isAll
+                ? alert.Zones.Count == 0 || alert.Zones.Contains(ZoneType.All)
+                : alert.Zones.Contains(zoneType);
+
+            if (!ImGui.Checkbox($"{zoneType.ToDisplayName()}##alertZoneOption{(byte)zoneType}", ref e))
+                continue;
+
+            if (isAll)
+            {
+                alert.Zones.Clear();
+                if (e)
+                    alert.Zones.Add(ZoneType.All);
+            }
+            else
+            {
+                alert.Zones.Remove(ZoneType.All);
+                alert.Zones.Remove(zoneType);
+                if (e)
+                    alert.Zones.Add(zoneType);
+                alert.Zones.Sort();
+            }
+
+            _changes = true;
         }
     }
 

--- a/ChatAlerts/ZoneType.cs
+++ b/ChatAlerts/ZoneType.cs
@@ -1,0 +1,122 @@
+using Lumina.Excel.Sheets;
+
+namespace ChatAlerts;
+
+public enum ZoneType : byte
+{
+    All            = 0,
+    Overworld      = 1,
+    Dungeon        = 2,
+    Trial          = 3,
+    Raid           = 4,
+    AllianceRaid   = 5,
+    DeepDungeon    = 6,
+    PvP            = 7,
+    Housing        = 8,
+    FieldOperation = 9,
+}
+
+public static class ZoneTypeExtensions
+{
+    public static string ToDisplayName(this ZoneType type) => type switch
+    {
+        ZoneType.Overworld    => "Overworld",
+        ZoneType.Dungeon      => "Dungeon",
+        ZoneType.Trial        => "Trial",
+        ZoneType.Raid         => "Raid",
+        ZoneType.AllianceRaid => "Alliance Raid",
+        ZoneType.DeepDungeon  => "Deep Dungeon",
+        ZoneType.PvP            => "PvP",
+        ZoneType.Housing        => "Housing",
+        ZoneType.FieldOperation => "Field Operation",
+        _                       => "All",
+    };
+
+    public static ZoneType FromTerritoryIntendedUse(uint useId) => useId switch
+    {
+        // Overworld
+        0  => ZoneType.Overworld, // Town
+        1  => ZoneType.Overworld, // OpenWorld
+        2  => ZoneType.Overworld, // Inn
+        5  => ZoneType.Overworld, // Jail
+        6  => ZoneType.Overworld, // OpeningArea
+        7  => ZoneType.Overworld, // LobbyArea
+        9  => ZoneType.Overworld, // OpenWorldInstanceBattle
+        15 => ZoneType.Overworld, // SoloOverworldInstance
+        20 => ZoneType.Overworld, // ChocoboRacing
+        21 => ZoneType.Overworld, // IshgardRestoration
+        22 => ZoneType.Overworld, // Wedding
+        23 => ZoneType.Overworld, // GoldSaucer
+        26 => ZoneType.Overworld, // ExploratoryMissions
+        27 => ZoneType.Overworld, // HallOfTheNovice
+        29 => ZoneType.Overworld, // SoloDuty
+        30 => ZoneType.Overworld, // FreeCompanyGarrison
+        32 => ZoneType.Overworld, // Seasonal
+        34 => ZoneType.Overworld, // SeasonalInstancedArea
+        35 => ZoneType.Overworld, // TripleTriadBattleHall
+        40 => ZoneType.Overworld, // PrivateEventArea
+        44 => ZoneType.Overworld, // LeapOfFaith
+        45 => ZoneType.Overworld, // MaskedCarnival
+        46 => ZoneType.Overworld, // OceanFishing
+        49 => ZoneType.Overworld, // IslandSanctuary
+        51 => ZoneType.Overworld, // TripleTriadInvitationalParlor
+        56 => ZoneType.Overworld, // Elysion
+        59 => ZoneType.Overworld, // Blunderville
+        60 => ZoneType.Overworld, // CosmicExploration
+        63 => ZoneType.Overworld, // SprigCleaning / Lilyswim
+
+        // Dungeon
+        3  => ZoneType.Dungeon, // Dungeon
+        4  => ZoneType.Dungeon, // VariantDungeon
+        33 => ZoneType.Dungeon, // TreasureDungeon
+        57 => ZoneType.Dungeon, // CriterionDungeon
+        58 => ZoneType.Dungeon, // SavageCriterionDungeon
+
+        // Trial
+        10 => ZoneType.Trial, // Trial (all difficulties)
+
+        // Raid
+        16 => ZoneType.Raid, // Raid (normal)
+        17 => ZoneType.Raid, // Raid (savage)
+
+        // Alliance Raid
+        8  => ZoneType.AllianceRaid, // AllianceRaid
+        36 => ZoneType.AllianceRaid, // ChaoticRaid
+
+        // Deep Dungeon
+        31 => ZoneType.DeepDungeon, // DeepDungeon
+
+        // Housing
+        13 => ZoneType.Housing, // HousingOutdoor
+        14 => ZoneType.Housing, // HousingIndoor
+
+        // PvP
+        18 => ZoneType.PvP, // Frontline
+        28 => ZoneType.PvP, // CrystallineConflict
+        37 => ZoneType.PvP, // CrystallineConflictCustomMatch
+        39 => ZoneType.PvP, // RivalWings
+
+        // Field Operation
+        41 => ZoneType.FieldOperation, // Eureka
+        48 => ZoneType.FieldOperation, // Bozja / Save the Queen
+        61 => ZoneType.FieldOperation, // OccultCrescent
+
+        _ => ZoneType.Overworld,
+    };
+
+    public static ZoneType GetCurrentZoneType(uint? territoryId = null)
+    {
+        var id = territoryId ?? Dalamud.ClientState.TerritoryType;
+        if (id == 0)
+            return ZoneType.Overworld;
+
+        if (Dalamud.ClientState.IsPvP)
+            return ZoneType.PvP;
+
+        var sheet = Dalamud.GameData.Excel.GetSheet<TerritoryType>();
+        if (sheet.TryGetRow(id, out var territory))
+            return FromTerritoryIntendedUse(territory.TerritoryIntendedUse.RowId);
+
+        return ZoneType.Overworld;
+    }
+}


### PR DESCRIPTION
Added an option to control which zone types an alert may trigger in. Default is All.

Zone IDs sourced from enum TerritoryIntendedUse in: https://github.com/redstrate/Physis/blob/main/src/common.rs